### PR TITLE
Hack in support for two OCR attempts at candy name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Built application files
 *.apk
+*.aab
 *.ap_
 
 # Files for the ART/Dalvik VM

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,8 +82,8 @@ android {
     defaultConfig {
         minSdkVersion 19 /*Dont change this unless you know why*/
         targetSdkVersion 28 /*Dont change this unless you know why*/
-        versionCode 66
-        versionName "5.4.5"
+        versionCode 68
+        versionName "5.5.1-beta"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,9 +162,15 @@ android {
         }
     }
 
+    // Change output dir of artifacts to live under builds subdir of /app
     android.applicationVariants.all { variant ->
+        def newDir = variant.baseName.replace("-", "/")
         variant.outputs.all {
-            outputFileName = "GoIV-${variant.name}.${variant.versionName}.apk"
+            def name = variant.baseName
+            if (!variant.baseName.startsWith("playstore")) {
+                name = name.replace("-release", "")
+            }
+            outputFileName = "../../builds/${newDir}/GoIV-${name}.${variant.versionName}.apk"
         }
     }
 }
@@ -205,7 +211,6 @@ dependencies {
     implementation project(':openCVLibrary330')
 
     /* for devMethods.thirdparty.pokebattler, temporally set for All Builds */
-//    implementation 'org.json:json:20160810' //used to generate moveset list
     implementation 'com.squareup.okhttp3:okhttp:3.7.0'//used to generate moveset list
 
     /**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,15 +162,9 @@ android {
         }
     }
 
-    // Change output dir of artifacts to live under builds subdir of /app
     android.applicationVariants.all { variant ->
-        def newDir = variant.baseName.replace("-", "/")
         variant.outputs.all {
-            def name = variant.baseName
-            if (!variant.baseName.startsWith("playstore")) {
-                name = name.replace("-release", "")
-            }
-            outputFileName = "../../builds/${newDir}/GoIV-${name}.${variant.versionName}.apk"
+            outputFileName = "GoIV-${variant.name}.${variant.versionName}.apk"
         }
     }
 }
@@ -211,6 +205,7 @@ dependencies {
     implementation project(':openCVLibrary330')
 
     /* for devMethods.thirdparty.pokebattler, temporally set for All Builds */
+//    implementation 'org.json:json:20160810' //used to generate moveset list
     implementation 'com.squareup.okhttp3:okhttp:3.7.0'//used to generate moveset list
 
     /**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,7 +83,7 @@ android {
         minSdkVersion 19 /*Dont change this unless you know why*/
         targetSdkVersion 29 /*Dont change this unless you know why*/
         versionCode 70
-        versionName "5.5.3-beta"
+        versionName "5.5.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,8 +82,8 @@ android {
     defaultConfig {
         minSdkVersion 19 /*Dont change this unless you know why*/
         targetSdkVersion 29 /*Dont change this unless you know why*/
-        versionCode 68
-        versionName "5.5.1-beta"
+        versionCode 69
+        versionName "5.5.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,7 @@ android {
      * Android SDK and build-tools version
      * Update (both Gradle and local SDK) whenever possible
      */
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     /**
      * Build configurations for APK
@@ -81,7 +81,7 @@ android {
      */
     defaultConfig {
         minSdkVersion 19 /*Dont change this unless you know why*/
-        targetSdkVersion 28 /*Dont change this unless you know why*/
+        targetSdkVersion 29 /*Dont change this unless you know why*/
         versionCode 68
         versionName "5.5.1-beta"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -205,7 +205,7 @@ dependencies {
     implementation project(':openCVLibrary330')
 
     /* for devMethods.thirdparty.pokebattler, temporally set for All Builds */
-    implementation 'org.json:json:20160810' //used to generate moveset list
+//    implementation 'org.json:json:20160810' //used to generate moveset list
     implementation 'com.squareup.okhttp3:okhttp:3.7.0'//used to generate moveset list
 
     /**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,8 +82,8 @@ android {
     defaultConfig {
         minSdkVersion 19 /*Dont change this unless you know why*/
         targetSdkVersion 29 /*Dont change this unless you know why*/
-        versionCode 69
-        versionName "5.5.2"
+        versionCode 70
+        versionName "5.5.3-beta"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,8 @@
 
         <service
             android:name=".Pokefly"
-            android:exported="true"/>
+            android:exported="true"
+            android:foregroundServiceType="mediaProjection"/>
         <service
             android:name=".updater.DownloadUpdateService"
             android:exported="false"/>

--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -62,7 +62,7 @@ public class GoIVSettings {
     public static final String DOWNLOADED_MOVESET_INFO = "downloaded_moveset_info_goiv";
 
     // Increment this value when you want to make all users recalibrate GoIV
-    public static int LATEST_SCREEN_CALIBRATION_VERSION = 1;
+    public static int LATEST_SCREEN_CALIBRATION_VERSION = 2;    
 
 
     private static GoIVSettings instance;

--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -285,7 +285,8 @@ public class GoIVSettings {
     }
 
     public boolean isPokeSpamEnabled() {
-        return prefs.getBoolean(POKESPAM_ENABLED, false);
+        //return prefs.getBoolean(POKESPAM_ENABLED, false);
+        return false; // Disabling PokeSpam because of Beyond Update
     }
 
     public boolean shouldAutoOpenExpandedAppraise() {

--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -106,6 +106,8 @@ public class GoIVSettings {
     }
 
     public void saveScreenCalibrationResults(ScanFieldResults results) {
+        results.finalAdjustments();
+
         SharedPreferences.Editor editor = prefs.edit();
         editor.putString(ScanFieldNames.POKEMON_NAME_AREA,
                 results.pokemonNameArea.toString());

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -62,6 +62,8 @@ import com.kamron.pogoiv.utils.fractions.FractionManager;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -204,7 +206,7 @@ public class Pokefly extends Service {
     public static void populateInfoIntent(Intent intent, ScanData scanData, @NonNull Optional<String> filePath) {
         intent.putExtra(KEY_SEND_INFO_NAME, scanData.getPokemonName());
         intent.putExtra(KEY_SEND_INFO_TYPE, scanData.getPokemonType());
-        intent.putExtra(KEY_SEND_INFO_CANDY, scanData.getCandyName());
+        intent.putExtra(KEY_SEND_INFO_CANDY, scanData.getCandyNames().toArray());
         intent.putExtra(KEY_SEND_INFO_GENDER, scanData.getPokemonGender());
         intent.putExtra(KEY_SEND_INFO_HP, scanData.getPokemonHP());
         intent.putExtra(KEY_SEND_INFO_CP, scanData.getPokemonCP());
@@ -827,7 +829,8 @@ public class Pokefly extends Service {
 
                     String pokemonName = intent.getStringExtra(KEY_SEND_INFO_NAME);
                     String pokemonType = intent.getStringExtra(KEY_SEND_INFO_TYPE);
-                    String candyName = intent.getStringExtra(KEY_SEND_INFO_CANDY);
+                    List<String> candyNames = Arrays.asList(intent.getStringArrayExtra(KEY_SEND_INFO_CANDY));
+
 
                     @SuppressWarnings("unchecked") Optional<String> lScreenShotFile =
                             (Optional<String>) intent.getSerializableExtra(KEY_SEND_SCREENSHOT_FILE);
@@ -870,7 +873,7 @@ public class Pokefly extends Service {
                             new LevelRange(estimatedPokemonLevelMin, estimatedPokemonLevelMax),
                             pokemonName,
                             pokemonType,
-                            candyName,
+                            candyNames,
                             pokemonGender,
                             pokemonHP,
                             pokemonCP,

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -78,6 +78,7 @@ public class Pokefly extends Service {
 
     public static final String ACTION_UPDATE_UI = "com.kamron.pogoiv.ACTION_UPDATE_UI";
     private static final String ACTION_SEND_INFO = "com.kamron.pogoiv.ACTION_SEND_INFO";
+    public static final String ACTION_REQUEST_SCREEN_GRABBER = "com.kamron.pogoiv.ACTION_REQUEST_SCREEN_GRABBER";
     private static final String ACTION_START = "com.kamron.pogoiv.ACTION_START";
     public static final String ACTION_STOP = "com.kamron.pogoiv.ACTION_STOP";
 
@@ -305,34 +306,47 @@ public class Pokefly extends Service {
         ivPreviewPrinter = new IVPreviewPrinter(this);
         clipboardTokenHandler = new ClipboardTokenHandler(this);
 
-        if (ACTION_STOP.equals(intent.getAction())) {
-            if (android.os.Build.VERSION.SDK_INT >= 24) {
-                stopForeground(STOP_FOREGROUND_DETACH);
-            }
-            stopSelf();
-            goIVNotificationManager.showPausedNotification();
+        switch (intent.getAction()) {
+            case ACTION_STOP:
+                if (android.os.Build.VERSION.SDK_INT >= 24) {
+                    stopForeground(STOP_FOREGROUND_DETACH);
+                }
+                stopSelf();
+                goIVNotificationManager.showPausedNotification();
+                break;
+            case ACTION_START:
+                GoIVSettings.reloadPreferences(this);
+                trainerLevel = intent.getIntExtra(KEY_TRAINER_LEVEL, Data.MINIMUM_TRAINER_LEVEL);
 
-        } else if (ACTION_START.equals(intent.getAction())) {
-            GoIVSettings.reloadPreferences(this);
-            trainerLevel = intent.getIntExtra(KEY_TRAINER_LEVEL, Data.MINIMUM_TRAINER_LEVEL);
+                setupDisplaySizeInfo();
 
-            setupDisplaySizeInfo();
+                createFlyingComponents();
 
-            createFlyingComponents();
+                startedInManualScreenshotMode = GoIVSettings.getInstance(this).isManualScreenshotModeEnabled();
+                if (!startedInManualScreenshotMode) {
+                    // Ask MainActivity to create a ScreenGrabber for us, and wait for it to finish
+                    LocalBroadcastManager.getInstance(this)
+                            .sendBroadcastSync(new Intent(ACTION_REQUEST_SCREEN_GRABBER));
+                    try {
+                        screen = ScreenGrabber.getInstance();
+                    } catch (Exception e) {
+                        // If for some reason MainActivity failed to make the ScreenGrabber, stop the service.
+                        // In this case we delete the notification to pretend it was never there in the first place.
+                        if (android.os.Build.VERSION.SDK_INT >= 24) {
+                            stopForeground(STOP_FOREGROUND_REMOVE);
+                        }
+                        stopSelf();
+                    }
+                    appraisalManager = new AppraisalManager(screen, this);
+                    screenWatcher = new ScreenWatcher(this, fractionManager, appraisalManager);
+                    screenWatcher.watchScreen();
 
-            startedInManualScreenshotMode = GoIVSettings.getInstance(this).isManualScreenshotModeEnabled();
-            /* Assumes MainActivity initialized ScreenGrabber before starting this service. */
-            if (!startedInManualScreenshotMode) {
-                screen = ScreenGrabber.getInstance();
-                appraisalManager = new AppraisalManager(screen, this);
-                screenWatcher = new ScreenWatcher(this, fractionManager, appraisalManager);
-                screenWatcher.watchScreen();
-
-            } else {
-                appraisalManager = new AppraisalManager(null, this);
-                screenShotHelper = ScreenShotHelper.start(Pokefly.this);
-            }
-            goIVNotificationManager.showRunningNotification();
+                } else {
+                    appraisalManager = new AppraisalManager(null, this);
+                    screenShotHelper = ScreenShotHelper.start(Pokefly.this);
+                }
+                goIVNotificationManager.showRunningNotification();
+                break;
         }
         //We have intent data, it's possible this service will be killed and we would want to recreate it
         //https://github.com/farkam135/GoIV/issues/477

--- a/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
@@ -86,7 +86,7 @@ public class ScreenGrabber {
     Bitmap grabScreen() {
         Image image = null;
         Bitmap bmp = null;
-        Integer retries = 60; // Retry for an entire second (given the rendering speed of 60fps)
+        int retries = 60; // Retry for an entire second (given the rendering speed of 60fps)
 
         while (retries > 0) {
             try {

--- a/app/src/main/java/com/kamron/pogoiv/activities/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/activities/MainActivity.java
@@ -102,12 +102,7 @@ public class MainActivity extends AppCompatActivity {
     private final BroadcastReceiver screenGrabberInitializer = new BroadcastReceiver() {
         @SuppressWarnings("checkstyle:EmptyCatchBlock")
         @Override public void onReceive(Context context, Intent intent) {
-            synchronized (MainActivity.this) {
-                initScreenGrabber();
-                try {
-                    MainActivity.this.wait();
-                } catch (InterruptedException ignored) { }
-            }
+            initScreenGrabber();
         }
     };
 
@@ -412,8 +407,6 @@ public class MainActivity extends AppCompatActivity {
     private void startPokeFly() {
         MainFragment.updateLaunchButtonText(this, R.string.main_starting, false);
 
-        startPoGoIfSettingOn();
-
         Intent intent = Pokefly
                 .createStartIntent(this, GoIVSettings.getInstance(this).getLevel());
         startService(intent);
@@ -459,10 +452,13 @@ public class MainActivity extends AppCompatActivity {
                             Context.MEDIA_PROJECTION_SERVICE);
                     MediaProjection mProjection = projectionManager.getMediaProjection(resultCode, data);
                     screen = ScreenGrabber.init(mProjection, rawDisplayMetrics);
-                    synchronized (this) { this.notify(); }
+                    startService(Pokefly.createBeginIntent(this));
                 } else {
                     updateLaunchButtonText(false, null);
                 }
+                // Launching Pokemon Go here might be a little slower, that right after starting Pokefly, but we need
+                // the MainActivity instance alive to answer the intent from Pokefly
+                startPoGoIfSettingOn();
                 break;
         }
     }

--- a/app/src/main/java/com/kamron/pogoiv/activities/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/activities/MainActivity.java
@@ -276,7 +276,9 @@ public class MainActivity extends AppCompatActivity {
      * areas.
      */
     private void initiateUserScreenSettings() {
-        Display display = getDisplay();
+        WindowManager windowManager = (WindowManager) getSystemService(WINDOW_SERVICE);
+        rawDisplayMetrics = new DisplayMetrics();
+        Display display = windowManager.getDefaultDisplay();
         display.getRealMetrics(rawDisplayMetrics);
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/activities/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/activities/MainActivity.java
@@ -337,6 +337,11 @@ public class MainActivity extends AppCompatActivity {
     @SuppressLint("NewApi")
     private void startGoIV() {
         startPokeFly();
+
+        boolean screenshotMode = GoIVSettings.getInstance(this).isManualScreenshotModeEnabled();
+        if (screenshotMode) {
+            startPoGoIfSettingOn();
+        }
     }
 
     private void startPoGoIfSettingOn() {

--- a/app/src/main/java/com/kamron/pogoiv/activities/OcrCalibrationResultActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/activities/OcrCalibrationResultActivity.java
@@ -196,6 +196,7 @@ public class OcrCalibrationResultActivity extends AppCompatActivity {
             ScanFieldResults results = new ScanFieldAutomaticLocator(
                     sCalibrationImage, sDisplayMetrics.widthPixels, sDisplayMetrics.density)
                     .scan(mainThreadHandler, dialogRef, new WeakReference<Context>(activity));
+            results.finalAdjustments();
 
             mainThreadHandler.post(new ResultRunnable(activityRef, dialogRef, results));
         }

--- a/app/src/main/java/com/kamron/pogoiv/activities/OcrCalibrationResultActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/activities/OcrCalibrationResultActivity.java
@@ -196,7 +196,6 @@ public class OcrCalibrationResultActivity extends AppCompatActivity {
             ScanFieldResults results = new ScanFieldAutomaticLocator(
                     sCalibrationImage, sDisplayMetrics.widthPixels, sDisplayMetrics.density)
                     .scan(mainThreadHandler, dialogRef, new WeakReference<Context>(activity));
-            results.finalAdjustments();
 
             mainThreadHandler.post(new ResultRunnable(activityRef, dialogRef, results));
         }

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/GoIVNotificationManager.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/GoIVNotificationManager.java
@@ -153,7 +153,12 @@ public class GoIVNotificationManager {
 
         initNotificationChannel(notificationManager);
 
-        pokefly.startForeground(NOTIFICATION_REQ_CODE, notification.build(), FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            pokefly.startForeground(NOTIFICATION_REQ_CODE, notification.build(),
+                    FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
+        } else {
+            pokefly.startForeground(NOTIFICATION_REQ_CODE, notification.build());
+        }
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/GoIVNotificationManager.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/GoIVNotificationManager.java
@@ -23,6 +23,8 @@ import com.kamron.pogoiv.activities.MainActivity;
 import com.kamron.pogoiv.activities.OcrCalibrationResultActivity;
 import com.kamron.pogoiv.activities.SettingsActivity;
 
+import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION;
+
 /**
  * Created by johan on 2017-07-06.
  * <p>
@@ -151,7 +153,7 @@ public class GoIVNotificationManager {
 
         initNotificationChannel(notificationManager);
 
-        pokefly.startForeground(NOTIFICATION_REQ_CODE, notification.build());
+        pokefly.startForeground(NOTIFICATION_REQ_CODE, notification.build(), FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -619,8 +619,9 @@ public class OcrHelper {
      * Correct some OCR errors in argument where only numbers are expected.
      */
     private static String fixOcrLettersToNums(String src) {
-        return src.replace("S", "5").replace("s", "5").replace("O", "0").replace("B", "8").replace("o",
-                "0").replace("l", "1").replace("I", "1").replace("i", "1").replace("Z", "2").replaceAll("[^0-9]", "");
+        return src.trim().replace("S", "5").replace("s", "5").replace("O", "0").replace("B", "8")
+                .replace("o", "0").replace("l", "1").replace("I", "1").replace("i", "1").replace("Z", "2")
+                .replaceAll("[^0-9]+$", "");
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -1100,6 +1100,7 @@ public class OcrHelper {
         }
         ensureCorrectLevelArcSettings(settings, trainerLevel); //todo, make it so it doesnt initiate on every scan?
         int totalOffset = 0;
+        boolean is_lucky = false;
         double offsetBase; // offsets are calculated off height of powerup candy cost field. Double to retain precision
         // Since we only care about height, its fine that we don't know the proper offset yet
         ScanArea powerUpCandyArea = ScanArea.calibratedFromSettings(POKEMON_POWER_UP_CANDY_COST, settings);
@@ -1132,6 +1133,7 @@ public class OcrHelper {
             if (hp.isPresent()) {
                 // Found successfully; assume this is a lucky pokemon and offset all further scans below that line
                 totalOffset += luckyOffset;
+                is_lucky = true;
             }
         }
 
@@ -1197,7 +1199,7 @@ public class OcrHelper {
                 .toString() + powerUpStardustCost.toString() + powerUpCandyCost.toString();
 
         return new ScanData(estimatedLevelRange, name, type, candyNames, gender, hp, cp, candyAmount, evolutionCost,
-                powerUpStardustCost, powerUpCandyCost, null, null, (totalOffset != 0), uniqueIdentifier);
+                powerUpStardustCost, powerUpCandyCost, null, null, is_lucky, uniqueIdentifier);
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanArea.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanArea.java
@@ -39,15 +39,15 @@ public class ScanArea {
      *
      * @param calibrationKey The key value used to find the saved user setting for the area, in the form of
      *                       "x,y,x2,y2".
-     * @param luckyOffset Amount to offset the scan region downward in case this is a lucky pokemon
+     * @param offset Amount to offset the scan region downward to deal with various dynamic UI changes (e.g. lucky)
      */
 
     @Nullable
-    public static ScanArea calibratedFromSettings(String calibrationKey, GoIVSettings settings, int luckyOffset) {
+    public static ScanArea calibratedFromSettings(String calibrationKey, GoIVSettings settings, int offset) {
         if (settings.hasManualScanCalibration()) {
             try {
                 String[] values = settings.getCalibrationValue(calibrationKey).split(",");
-                return new ScanArea(Integer.valueOf(values[0]), Integer.valueOf(values[1]) + luckyOffset,
+                return new ScanArea(Integer.valueOf(values[0]), Integer.valueOf(values[1]) + offset,
                         Integer.valueOf(values[2]), Integer.valueOf(values[3]));
             } catch (Exception e) {
                 return null;

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldAutomaticLocator.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldAutomaticLocator.java
@@ -33,6 +33,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import static java.lang.Math.abs;
+
 
 /**
  * Created by johan on 2017-07-27.
@@ -203,7 +205,7 @@ public class ScanFieldAutomaticLocator {
                 } else if (r.width - maxRect.width > screenshotDensity) {
                     // Take the largest
                     maxRect = r;
-                } else if (Math.abs(r.width - maxRect.width) < screenshotDensity && r.y < maxRect.y) {
+                } else if (abs(r.width - maxRect.width) < screenshotDensity && r.y < maxRect.y) {
                     // Take the upper with same width
                     maxRect = r;
                 }
@@ -276,6 +278,7 @@ public class ScanFieldAutomaticLocator {
         String findingName = null;
         String findingType = null;
         String findingGender = null;
+        String findingStardustLabel = null;
         String findingCandyName = null;
         String findingHp = null;
         String findingCp = null;
@@ -291,6 +294,7 @@ public class ScanFieldAutomaticLocator {
             findingName = context.getString(R.string.ocr_finding_name);
             findingType = context.getString(R.string.ocr_finding_type);
             findingGender = context.getString(R.string.ocr_finding_gender);
+            findingStardustLabel = "Finding STARDUST label";
             findingCandyName = context.getString(R.string.ocr_finding_candy_name);
             findingHp = context.getString(R.string.ocr_finding_hp);
             findingCp = context.getString(R.string.ocr_finding_cp);
@@ -317,8 +321,11 @@ public class ScanFieldAutomaticLocator {
         postMessage(mainThreadHandler, dialog.get(), findingCandyAmount);
         findPokemonCandyAmountArea(results);
 
+        postMessage(mainThreadHandler, dialog.get(), findingStardustLabel);
+        int stardustHeight = findStardustLabelHeight(results);
+
         postMessage(mainThreadHandler, dialog.get(), findingCandyName);
-        findPokemonCandyNameArea(results);
+        findPokemonCandyNameArea(results, stardustHeight);
 
         postMessage(mainThreadHandler, dialog.get(), findingHp);
         findPokemonHPArea(results);
@@ -327,13 +334,13 @@ public class ScanFieldAutomaticLocator {
         findPokemonCPScanArea(results);
 
         postMessage(mainThreadHandler, dialog.get(), findingEvolutionCost);
-        findPokemonEvolutionCostArea(results); // Always call after findPokemonCandyAmountArea
-
-        postMessage(mainThreadHandler, dialog.get(), findingPowerUpStardustCost);
-        findPokemonPowerUpStardustCostArea(results); // Always call after findPokemonCandyAmountArea
+        findPokemonEvolutionCostArea(results);
 
         postMessage(mainThreadHandler, dialog.get(), findingPowerUpCandyCost);
-        findPokemonPowerUpCandyCostArea(results); // Always call after findPokemonCandyAmountArea
+        findPokemonPowerUpCandyCostArea(results); // Always call after findPokemonEvolutionCostArea
+
+        postMessage(mainThreadHandler, dialog.get(), findingPowerUpStardustCost);
+        findPokemonPowerUpStardustCostArea(results); // Always call after findPokemonEvolutionCostArea
 
         postMessage(mainThreadHandler, dialog.get(), findingLevelArc);
         findArcValues(results);
@@ -524,11 +531,9 @@ public class ScanFieldAutomaticLocator {
      */
     private void findPokemonEvolutionCostArea(ScanFieldResults results) {
         final boolean debugExecution = false; // Activate this flag to display the onscreen debug graphics
-
-        //noinspection UnusedAssignment
         Canvas c = null;
-        //noinspection UnusedAssignment
         Paint p = null;
+
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
             c = new Canvas(bmp);
@@ -537,7 +542,7 @@ public class ScanFieldAutomaticLocator {
             debugPrintRectList(boundingRectList, c, p);
         }
 
-        if (powerUpButton == null || results.pokemonCandyAmountArea == null) {
+        if (powerUpButton == null) {
             return;
         }
 
@@ -545,14 +550,11 @@ public class ScanFieldAutomaticLocator {
                 // Keep only rect that are below the power up button and above the height of the evolution button
                 .filter(ByMinY.of(powerUpButton.y + powerUpButton.height))
                 .filter(ByMaxY.of((int) (powerUpButton.y + powerUpButton.height * 2.5f)))
-                // Keep only bounding rect between the pokemonCandyAmountArea x coordinates
-                .filter(ByMinX.of(results.pokemonCandyAmountArea.xPoint))
-                .filter(ByMaxX.of(results.pokemonCandyAmountArea.xPoint + results.pokemonCandyAmountArea.width))
+                .filter(ByMinX.of(width50Percent))
                 .toList();
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.RED);
             debugPrintRectList(candidates, c, p);
         }
@@ -577,7 +579,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.YELLOW);
             debugPrintRectList(candidates, c, p);
         }
@@ -589,7 +590,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.GREEN);
             debugPrintRectList(candidates, c, p);
         }
@@ -623,11 +623,9 @@ public class ScanFieldAutomaticLocator {
      */
     private void findPokemonPowerUpStardustCostArea(ScanFieldResults results) {
         final boolean debugExecution = false; // Activate this flag to display the onscreen debug graphics
-
-        //noinspection UnusedAssignment
         Canvas c = null;
-        //noinspection UnusedAssignment
         Paint p = null;
+
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
             c = new Canvas(bmp);
@@ -636,7 +634,7 @@ public class ScanFieldAutomaticLocator {
             debugPrintRectList(boundingRectList, c, p);
         }
 
-        if (powerUpButton == null || results.pokemonCandyAmountArea == null) {
+        if (powerUpButton == null || results.pokemonEvolutionCostArea == null) {
             return;
         }
 
@@ -644,14 +642,13 @@ public class ScanFieldAutomaticLocator {
                 // Keep only rect that are between the power up button Y coordinates
                 .filter(ByMinY.of(powerUpButton.y))
                 .filter(ByMaxY.of(powerUpButton.y + powerUpButton.height))
-                // Keep only bounding rect between half width and candy amount rect start
+                // Keep only bounding rect between half width and evolution cost rect start
                 .filter(ByMinX.of(width50Percent))
-                .filter(ByMaxX.of(results.pokemonCandyAmountArea.xPoint))
+                .filter(ByMaxX.of(results.pokemonEvolutionCostArea.xPoint))
                 .toList();
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.RED);
             debugPrintRectList(candidates, c, p);
         }
@@ -665,7 +662,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.YELLOW);
             debugPrintRectList(candidates, c, p);
         }
@@ -677,7 +673,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.GREEN);
             debugPrintRectList(candidates, c, p);
         }
@@ -704,11 +699,9 @@ public class ScanFieldAutomaticLocator {
      */
     private void findPokemonPowerUpCandyCostArea(ScanFieldResults results) {
         final boolean debugExecution = false; // Activate this flag to display the onscreen debug graphics
-
-        //noinspection UnusedAssignment
         Canvas c = null;
-        //noinspection UnusedAssignment
         Paint p = null;
+
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
             c = new Canvas(bmp);
@@ -717,7 +710,7 @@ public class ScanFieldAutomaticLocator {
             debugPrintRectList(boundingRectList, c, p);
         }
 
-        if (powerUpButton == null || results.pokemonCandyAmountArea == null) {
+        if (powerUpButton == null || results.pokemonEvolutionCostArea == null) {
             return;
         }
 
@@ -726,13 +719,12 @@ public class ScanFieldAutomaticLocator {
                 .filter(ByMinY.of(powerUpButton.y))
                 .filter(ByMaxY.of(powerUpButton.y + powerUpButton.height))
                 // Keep only bounding rect between the candy amount area X coordinates
-                .filter(ByMinX.of(results.pokemonCandyAmountArea.xPoint))
-                .filter(ByMaxX.of(results.pokemonCandyAmountArea.xPoint + results.pokemonCandyAmountArea.width))
+                .filter(ByMinX.of(results.pokemonEvolutionCostArea.xPoint))
+                .filter(ByMaxX.of(results.pokemonEvolutionCostArea.xPoint + results.pokemonEvolutionCostArea.width))
                 .toList();
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.RED);
             debugPrintRectList(candidates, c, p);
         }
@@ -746,7 +738,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.YELLOW);
             debugPrintRectList(candidates, c, p);
         }
@@ -758,7 +749,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.GREEN);
             debugPrintRectList(candidates, c, p);
         }
@@ -771,8 +761,8 @@ public class ScanFieldAutomaticLocator {
 
         // Increase the width of 10% on the left
         result.x -= result.width * 0.1;
-        // Make it end exactly where Pokémon candy amount ends
-        result.width = (results.pokemonCandyAmountArea.xPoint + results.pokemonCandyAmountArea.width) - result.x;
+        // Make it end exactly where Pokémon evolution cost ends
+        result.width = (results.pokemonEvolutionCostArea.xPoint + results.pokemonEvolutionCostArea.width) - result.x;
 
         // Increase the height of 20% on top and 20% below
         result.y -= result.height * 0.2;
@@ -1013,9 +1003,97 @@ public class ScanFieldAutomaticLocator {
     }
 
     /**
+     * Find the height of the STARDUST label (used fixing the candy name area height)
+     */
+    private int findStardustLabelHeight(ScanFieldResults results) {
+        final boolean debugExecution = false; // Activate this flag to display the onscreen debug graphics
+        Canvas c = null;
+        Paint p = null;
+
+        //noinspection PointlessBooleanExpression
+        if (BuildConfig.DEBUG && debugExecution) {
+            c = new Canvas(bmp);
+            p = getDebugPaint();
+            p.setColor(Color.MAGENTA);
+            //debugPrintRectList(boundingRectList, c, p);
+        }
+
+        if (  (greyHorizontalLine == null && results.pokemonCandyAmountArea == null)
+            || powerUpButton == null) {
+            return 0;
+        }
+
+        int upperBound;
+        if (results.pokemonCandyAmountArea != null) {
+            upperBound = results.pokemonCandyAmountArea.yPoint + results.pokemonCandyAmountArea.height;
+        } else {
+            upperBound = greyHorizontalLine.y + greyHorizontalLine.height;
+        }
+
+        //noinspection PointlessBooleanExpression
+        if (BuildConfig.DEBUG && debugExecution) {
+            c = new Canvas(bmp);
+            p = getDebugPaint();
+            p.setColor(Color.BLUE);
+            debugPrintRectList(Collections.singletonList(greyHorizontalLine), c, p);
+            debugPrintRectList(Collections.singletonList(powerUpButton), c, p);
+            debugPrintLineVertical(width33Percent, c, p);
+            debugPrintLineVertical(greyHorizontalLine.x, c, p);
+            debugPrintLineHorizontal(upperBound, c, p);
+            debugPrintLineHorizontal(powerUpButton.y, c, p);
+        }
+
+        List<Rect> candidates = FluentIterable.from(boundingRectList)
+                // Keep only bounding rect between 50% of the image width, before the end of the horizontal grey
+                // divider line and below it and above the power up button
+                .filter(Predicates.and(ByMinX.of(greyHorizontalLine.x),
+                        ByMaxX.of(width33Percent),
+                        ByMinY.of(upperBound),
+                        ByMaxY.of(powerUpButton.y)))
+                .toList();
+
+        //noinspection PointlessBooleanExpression
+        if (BuildConfig.DEBUG && debugExecution) {
+            p.setColor(Color.RED);
+            debugPrintRectList(candidates, c, p);
+        }
+
+        candidates = FluentIterable.from(candidates)
+                // Check if the dominant color of the contour matches the light green hue of PoGO small text
+                .filter(ByHsvColor.of(image, mask1, contours, boundingRectList, HSV_GREEN_LIGHT, 5, 0.125f, 0.090f))
+                .toList();
+
+        //noinspection PointlessBooleanExpression
+        if (BuildConfig.DEBUG && debugExecution) {
+            p.setColor(Color.YELLOW);
+            debugPrintRectList(candidates, c, p);
+        }
+
+        candidates = FluentIterable.from(candidates)
+                // Remove the outliers
+                .filter(ByChauvenetCriterionOnBottomY.of(candidates))
+                .toList();
+
+        //noinspection PointlessBooleanExpression
+        if (BuildConfig.DEBUG && debugExecution) {
+            p.setColor(Color.GREEN);
+            debugPrintRectList(candidates, c, p);
+        }
+
+        if (candidates.size() == 0) {
+            return 0;
+        }
+
+        Rect result = mergeRectList(candidates);
+
+        // increase the height by 20% on each side (like candy name)
+        return result.height;
+    }
+
+    /**
      * Find the area where the candy name (such as "eevee candy") is listed.
      */
-    private void findPokemonCandyNameArea(ScanFieldResults results) {
+    private void findPokemonCandyNameArea(ScanFieldResults results, int stardustHeight) {
         final boolean debugExecution = false; // Activate this flag to display the onscreen debug graphics
         Canvas c = null;
         Paint p = null;
@@ -1028,7 +1106,8 @@ public class ScanFieldAutomaticLocator {
             debugPrintRectList(boundingRectList, c, p);
         }
 
-        if (greyHorizontalLine == null || powerUpButton == null) {
+        if (  (greyHorizontalLine == null && results.pokemonCandyAmountArea == null)
+            || powerUpButton == null) {
             return;
         }
 
@@ -1104,9 +1183,16 @@ public class ScanFieldAutomaticLocator {
             result.width = width90Percent - result.x;
         }
 
+        // Using the height of the stardust label allows us to get a good calibration on wrapped text
+        if (stardustHeight > 0) {
+            if (abs(stardustHeight - result.height) > Math.min(stardustHeight, result.height) * 0.1) {
+                results.candyNameWrapped = true;
+            }
+            result.height = stardustHeight;
+        }
         // Increase the height of 20% on top and 20% below
         result.y -= result.height * 0.2;
-        result.height += result.height * 0.4;
+        result.height *= 1.4;
 
         results.candyNameArea = new ScanArea(result.x, result.y, result.width, result.height);
     }
@@ -1149,7 +1235,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.RED);
             debugPrintRectList(candidates, c, p);
         }
@@ -1161,7 +1246,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.YELLOW);
             debugPrintRectList(candidates, c, p);
         }
@@ -1173,7 +1257,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.GREEN);
             debugPrintRectList(candidates, c, p);
         }
@@ -1536,7 +1619,7 @@ public class ScanFieldAutomaticLocator {
         }
 
         @Override public boolean apply(@Nullable Rect input) {
-            return input != null && Math.abs(input.width - targetWidth) < delta;
+            return input != null && abs(input.width - targetWidth) < delta;
         }
     }
 
@@ -1554,7 +1637,7 @@ public class ScanFieldAutomaticLocator {
         }
 
         @Override public boolean apply(@Nullable Rect input) {
-            return input != null && Math.abs(input.height - targetHeight) < delta;
+            return input != null && abs(input.height - targetHeight) < delta;
         }
     }
 
@@ -1643,11 +1726,11 @@ public class ScanFieldAutomaticLocator {
                 Imgproc.drawContours(mask, contours, contours.indexOf(contour), SCALAR_ON, -1);
                 Scalar meanColor = Core.mean(image, mask);
                 Color.RGBToHSV((int) meanColor.val[0], (int) meanColor.val[1], (int) meanColor.val[2], meanHsv);
-                if ((Math.abs(color[0] - meanHsv[0]) <= dH
+                if ((abs(color[0] - meanHsv[0]) <= dH
                         || meanHsv[0] > 360 + color[0] - dH
                         || meanHsv[0] < -color[0] + dH)
-                        && Math.abs(color[1] - meanHsv[1]) <= dS
-                        && Math.abs(color[2] - meanHsv[2]) <= dV) {
+                        && abs(color[1] - meanHsv[1]) <= dS
+                        && abs(color[2] - meanHsv[2]) <= dV) {
                     return true;
                 }
             }

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldAutomaticLocator.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldAutomaticLocator.java
@@ -314,6 +314,9 @@ public class ScanFieldAutomaticLocator {
         postMessage(mainThreadHandler, dialog.get(), findingGender);
         findPokemonGenderArea(results);
 
+        postMessage(mainThreadHandler, dialog.get(), findingCandyAmount);
+        findPokemonCandyAmountArea(results);
+
         postMessage(mainThreadHandler, dialog.get(), findingCandyName);
         findPokemonCandyNameArea(results);
 
@@ -322,9 +325,6 @@ public class ScanFieldAutomaticLocator {
 
         postMessage(mainThreadHandler, dialog.get(), findingCp);
         findPokemonCPScanArea(results);
-
-        postMessage(mainThreadHandler, dialog.get(), findingCandyAmount);
-        findPokemonCandyAmountArea(results);
 
         postMessage(mainThreadHandler, dialog.get(), findingEvolutionCost);
         findPokemonEvolutionCostArea(results); // Always call after findPokemonCandyAmountArea
@@ -787,11 +787,9 @@ public class ScanFieldAutomaticLocator {
      */
     private void findPokemonCandyAmountArea(ScanFieldResults results) {
         final boolean debugExecution = false; // Activate this flag to display the onscreen debug graphics
-
-        //noinspection UnusedAssignment
         Canvas c = null;
-        //noinspection UnusedAssignment
         Paint p = null;
+
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
             c = new Canvas(bmp);
@@ -820,19 +818,17 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.RED);
             debugPrintRectList(candidates, c, p);
         }
 
         candidates = FluentIterable.from(candidates)
-                // Check if the dominant color of the contour matches the light green hue of PoGO text
+                // Check if the dominant color of the contour matches the dark green hue of PoGO text
                 .filter(ByHsvColor.of(image, mask1, contours, boundingRectList, HSV_GREEN_DARK, 5, 0.275f, 0.275f))
                 .toList();
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.YELLOW);
             debugPrintRectList(candidates, c, p);
         }
@@ -844,7 +840,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.GREEN);
             debugPrintRectList(candidates, c, p);
         }
@@ -1022,11 +1017,9 @@ public class ScanFieldAutomaticLocator {
      */
     private void findPokemonCandyNameArea(ScanFieldResults results) {
         final boolean debugExecution = false; // Activate this flag to display the onscreen debug graphics
-
-        //noinspection UnusedAssignment
         Canvas c = null;
-        //noinspection UnusedAssignment
         Paint p = null;
+
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
             c = new Canvas(bmp);
@@ -1039,6 +1032,13 @@ public class ScanFieldAutomaticLocator {
             return;
         }
 
+        int upperBound;
+        if (results.pokemonCandyAmountArea != null) {
+            upperBound = results.pokemonCandyAmountArea.yPoint + results.pokemonCandyAmountArea.height;
+        } else {
+            upperBound = greyHorizontalLine.y + greyHorizontalLine.height;
+        }
+
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
             c = new Canvas(bmp);
@@ -1048,7 +1048,7 @@ public class ScanFieldAutomaticLocator {
             debugPrintRectList(Collections.singletonList(powerUpButton), c, p);
             debugPrintLineVertical(width33Percent, c, p);
             debugPrintLineVertical(greyHorizontalLine.x + greyHorizontalLine.width, c, p);
-            debugPrintLineHorizontal(greyHorizontalLine.y + greyHorizontalLine.height, c, p);
+            debugPrintLineHorizontal(upperBound, c, p);
             debugPrintLineHorizontal(powerUpButton.y, c, p);
         }
 
@@ -1057,13 +1057,12 @@ public class ScanFieldAutomaticLocator {
                 // divider line and below it and above the power up button
                 .filter(Predicates.and(ByMinX.of(width33Percent),
                         ByMaxX.of(greyHorizontalLine.x + greyHorizontalLine.width),
-                        ByMinY.of(greyHorizontalLine.y + greyHorizontalLine.height),
+                        ByMinY.of(upperBound),
                         ByMaxY.of(powerUpButton.y)))
                 .toList();
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.RED);
             debugPrintRectList(candidates, c, p);
         }
@@ -1075,7 +1074,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.YELLOW);
             debugPrintRectList(candidates, c, p);
         }
@@ -1087,7 +1085,6 @@ public class ScanFieldAutomaticLocator {
 
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
-            //noinspection ConstantConditions
             p.setColor(Color.GREEN);
             debugPrintRectList(candidates, c, p);
         }
@@ -1119,11 +1116,9 @@ public class ScanFieldAutomaticLocator {
      */
     private void findPokemonTypeArea(ScanFieldResults results) {
         final boolean debugExecution = false; // Activate this flag to display the onscreen debug graphics
-
-        //noinspection UnusedAssignment
         Canvas c = null;
-        //noinspection UnusedAssignment
         Paint p = null;
+
         //noinspection PointlessBooleanExpression
         if (BuildConfig.DEBUG && debugExecution) {
             c = new Canvas(bmp);

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldAutomaticLocator.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldAutomaticLocator.java
@@ -79,6 +79,7 @@ public class ScanFieldAutomaticLocator {
     private final float screenshotDensity;
     private final int width20Percent;
     private final int width25Percent;
+    private final int width33Percent;
     private final int width50Percent;
     private final int width66Percent;
     private final int width80Percent;
@@ -91,6 +92,7 @@ public class ScanFieldAutomaticLocator {
         screenshotDensity = bmp.getWidth() * displayDensity / displayWidth;
         width20Percent = bmp.getWidth() / 5;
         width25Percent = bmp.getWidth() / 4;
+        width33Percent = bmp.getWidth() / 3;
         width50Percent = bmp.getWidth() / 2;
         width66Percent = bmp.getWidth() / 3 * 2;
         width80Percent = bmp.getWidth() / 5 * 4;
@@ -1044,7 +1046,7 @@ public class ScanFieldAutomaticLocator {
             p.setColor(Color.BLUE);
             debugPrintRectList(Collections.singletonList(greyHorizontalLine), c, p);
             debugPrintRectList(Collections.singletonList(powerUpButton), c, p);
-            debugPrintLineVertical(width50Percent, c, p);
+            debugPrintLineVertical(width33Percent, c, p);
             debugPrintLineVertical(greyHorizontalLine.x + greyHorizontalLine.width, c, p);
             debugPrintLineHorizontal(greyHorizontalLine.y + greyHorizontalLine.height, c, p);
             debugPrintLineHorizontal(powerUpButton.y, c, p);
@@ -1053,7 +1055,7 @@ public class ScanFieldAutomaticLocator {
         List<Rect> candidates = FluentIterable.from(boundingRectList)
                 // Keep only bounding rect between 50% of the image width, before the end of the horizontal grey
                 // divider line and below it and above the power up button
-                .filter(Predicates.and(ByMinX.of(width50Percent),
+                .filter(Predicates.and(ByMinX.of(width33Percent),
                         ByMaxX.of(greyHorizontalLine.x + greyHorizontalLine.width),
                         ByMinY.of(greyHorizontalLine.y + greyHorizontalLine.height),
                         ByMaxY.of(powerUpButton.y)))
@@ -1096,9 +1098,9 @@ public class ScanFieldAutomaticLocator {
 
         Rect result = mergeRectList(candidates);
 
-        // Ensure the rect starts at 50% of the width
-        if (result.x > width50Percent) {
-            result.x = width50Percent;
+        // Ensure the rect starts at 33% of the width
+        if (result.x > width33Percent) {
+            result.x = width33Percent;
         }
         // Ensure the rect reaches the 90% of the width
         if (result.x + result.width < width90Percent) {

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldResults.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldResults.java
@@ -12,15 +12,16 @@ public class ScanFieldResults {
     public ScanArea pokemonHpArea;
     public ScanArea pokemonCpArea;
     public ScanArea pokemonCandyAmountArea = null;
-    public ScanArea pokemonEvolutionCostArea;
-    public ScanArea pokemonPowerUpStardustCostArea;
-    public ScanArea pokemonPowerUpCandyCostArea;
+    public ScanArea pokemonEvolutionCostArea = null;
+    public ScanArea pokemonPowerUpStardustCostArea = null;
+    public ScanArea pokemonPowerUpCandyCostArea = null;
     public ScanPoint arcCenter;
     public Integer arcRadius;
     public ScanPoint infoScreenCardWhitePixelPoint;
     public @ColorInt Integer infoScreenCardWhitePixelColor;
     public ScanPoint infoScreenFabGreenPixelPoint;
     public @ColorInt Integer infoScreenFabGreenPixelColor;
+    public Boolean candyNameWrapped = false;
 
     public boolean isCompleteCalibration() {
         return pokemonNameArea != null
@@ -39,6 +40,27 @@ public class ScanFieldResults {
                 && infoScreenCardWhitePixelColor != null
                 && infoScreenFabGreenPixelPoint != null
                 && infoScreenFabGreenPixelColor != null;
+    }
+
+    /**
+     * Adjusts the relevant scan areas upwards if the calibration pokemon's candy text wrapped to a second line
+     */
+    public void finalAdjustments() {
+        if (!candyNameWrapped) {
+            return;
+        }
+        // Same as in OcrHelper
+        int adj = (int) (candyNameArea.height * 0.8);
+
+        if (pokemonPowerUpCandyCostArea != null) {
+            pokemonPowerUpCandyCostArea.yPoint -= adj;
+        }
+        if (pokemonPowerUpStardustCostArea != null) {
+            pokemonPowerUpStardustCostArea.yPoint -= adj;
+        }
+        if (pokemonEvolutionCostArea != null) {
+            pokemonEvolutionCostArea.yPoint -= adj;
+        }
     }
 
 }

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldResults.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanFieldResults.java
@@ -11,7 +11,7 @@ public class ScanFieldResults {
     public ScanArea candyNameArea;
     public ScanArea pokemonHpArea;
     public ScanArea pokemonCpArea;
-    public ScanArea pokemonCandyAmountArea;
+    public ScanArea pokemonCandyAmountArea = null;
     public ScanArea pokemonEvolutionCostArea;
     public ScanArea pokemonPowerUpStardustCostArea;
     public ScanArea pokemonPowerUpCandyCostArea;

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -201,7 +201,8 @@ public class PokeInfoCalculator {
         // END patch for supporting discontinuous pokedex number pokemons
 
         for (int i = 0; i < pokeListSize; i++) {
-            PokemonBase p = new PokemonBase(names[i], displayNames[i], i, devolution[i], evolutionCandyCost[i]);
+            PokemonBase p = new PokemonBase(names[i], displayNames[i], i, devolution[i],
+                                            candyNamesArray[i], evolutionCandyCost[i]);
             pokedex.add(p);
         }
 
@@ -445,6 +446,16 @@ public class PokeInfoCalculator {
             base = get(base.devoNumber);
         }
         return base;
+    }
+
+    /**
+     * Returns the pokemon whose name matches the candy type for the given pokemon
+     *      e.g. getCandyPokemon(Machamp) -> Machop
+     * @param pokemon the pokemon whose candy form is wanted
+     * @return the pokemon that matches the candy type for the given pokemon
+     */
+    public Pokemon getCandyPokemon(Pokemon pokemon) {
+        return getForm(pokemon.candyNameNumber);
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/Pokemon.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/Pokemon.java
@@ -80,6 +80,8 @@ public class Pokemon {
     // Copy of the value in the base class
     public final int devoNumber;
     // Copy of the value in the base class
+    public final int candyNameNumber;
+    // Copy of the value in the base class
     public final int candyEvolutionCost;
 
     public Pokemon(PokemonBase base, @NonNull String formName, int baseAttack, int baseDefense, int baseStamina) {
@@ -95,6 +97,7 @@ public class Pokemon {
         this.baseDefense = baseDefense;
         this.baseStamina = baseStamina;
         this.devoNumber = base.devoNumber;
+        this.candyNameNumber = base.candyNameNumber;
         this.candyEvolutionCost = base.candyEvolutionCost;
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonBase.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonBase.java
@@ -64,6 +64,18 @@ public class PokemonBase {
                 return form;
             }
         }
+
+        if (formName.equals("")) {
+            // Empty string means we want the "default" form. For pokemon with multiple forms, this will
+            // have the formName "Normal Form". If there isn't a default, just get the first (e.g. Shellos East/West)
+            Pokemon normalForm = getForm("Normal Form");
+            if (normalForm != null) {
+                return normalForm;
+            }
+            return forms.get(0);
+        }
+
+        // Only return null if we wanted a specific form and failed to find it.
         return null;
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonBase.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonBase.java
@@ -38,15 +38,18 @@ public class PokemonBase {
 
     public final int number; //index number in resources, pokedex number - 1
     public final int devoNumber;
+    public final int candyNameNumber;
     public final int candyEvolutionCost;
 
-    public PokemonBase(String name, String displayName, int number, int devoNumber, int candyEvolutionCost) {
+    public PokemonBase(String name, String displayName, int number, int devoNumber,
+                       int candyNameNumber, int candyEvolutionCost) {
         this.name = name;
         this.displayName = displayName;
         this.number = number;
         this.devoNumber = devoNumber;
         this.evolutions = new ArrayList<>();
         this.forms = new ArrayList<>();
+        this.candyNameNumber = candyNameNumber;
         this.candyEvolutionCost = candyEvolutionCost;
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
@@ -48,9 +48,13 @@ public class ScanData {
         this.pokemonType = pokemonType;
         this.normalizedPokemonType = StringUtils.normalize(pokemonType);
         this.pokemonGender = pokemonGender;
-        this.candyNames = candyNames;
+        if (candyNames == null) {
+            this.candyNames = new ArrayList();
+        } else {
+            this.candyNames = candyNames;
+        }
         this.normalizedCandyNames = new ArrayList();
-        for (String candyName : candyNames) {
+        for (String candyName : this.candyNames) {
             this.normalizedCandyNames.add(StringUtils.normalize(candyName));
         }
         this.pokemonHP = pokemonHP;

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
@@ -7,6 +7,9 @@ import com.google.common.base.Optional;
 import com.kamron.pogoiv.utils.LevelRange;
 import com.kamron.pogoiv.utils.StringUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A ScanData represents the result of an OCR scan.
  * Created by pgiarrusso on 3/9/2016.
@@ -20,8 +23,8 @@ public class ScanData {
     private final String pokemonType;
     private final String normalizedPokemonType;
     private final Pokemon.Gender pokemonGender;
-    private final String candyName;
-    private final String normalizedCandyName;
+    private final List<String> candyNames;
+    private final List<String> normalizedCandyNames;
     private Optional<Integer> pokemonHP;
     private Optional<Integer> pokemonCP;
     private Optional<Integer> pokemonCandyAmount;
@@ -34,7 +37,7 @@ public class ScanData {
     private final String uniqueID;
     private Pokemon pokemon = null;
 
-    public ScanData(LevelRange estimatedPokemonLevel, String pokemonName, String pokemonType, String candyName,
+    public ScanData(LevelRange estimatedPokemonLevel, String pokemonName, String pokemonType, List<String> candyNames,
                     Pokemon.Gender pokemonGender, Optional<Integer> pokemonHP, Optional<Integer> pokemonCP,
                     Optional<Integer> pokemonCandyAmount, Optional<Integer> evolutionCandyCost,
                     Optional<Integer> powerUpStardustCost, Optional<Integer> powerUpCandyCost,
@@ -45,8 +48,11 @@ public class ScanData {
         this.pokemonType = pokemonType;
         this.normalizedPokemonType = StringUtils.normalize(pokemonType);
         this.pokemonGender = pokemonGender;
-        this.candyName = candyName;
-        this.normalizedCandyName = StringUtils.normalize(candyName);
+        this.candyNames = candyNames;
+        this.normalizedCandyNames = new ArrayList();
+        for (String candyName : candyNames) {
+            this.normalizedCandyNames.add(StringUtils.normalize(candyName));
+        }
         this.pokemonHP = pokemonHP;
         this.pokemonCP = pokemonCP;
         this.pokemonCandyAmount = pokemonCandyAmount;
@@ -69,7 +75,7 @@ public class ScanData {
                         + "hp:%d\n"
                         + "lucky:%B\n\n"
 
-                        + "candy_name:%s\n"
+                        + "candy_name:%s or %s\n"
                         + "candy_amount:%d\n"
                         + "evolution_candy:%d\n"
                         + "powerup_candy:%d\n"
@@ -84,7 +90,8 @@ public class ScanData {
                 pokemonHP.or(-1),
                 isLucky,
 
-                candyName,
+                candyNames.get(0),
+                candyNames.get(1),
                 pokemonCandyAmount.or(-1),
                 evolutionCandyCost.or(-1),
                 powerUpCandyCost.or(-1),
@@ -102,9 +109,7 @@ public class ScanData {
         this.estimatedPokemonLevelRange = levelRange;
     }
 
-    public String getPokemonName() {
-        return pokemonName;
-    }
+    public String getPokemonName() { return pokemonName; }
 
     public String getNormalizedPokemonName() {
         return normalizedPokemonName;
@@ -127,13 +132,9 @@ public class ScanData {
         return pokemonGender;
     }
 
-    public String getCandyName() {
-        return candyName;
-    }
+    public List<String> getCandyNames() { return candyNames; }
 
-    public String getNormalizedCandyName() {
-        return normalizedCandyName;
-    }
+    public List<String> getNormalizedCandyNames() { return normalizedCandyNames; }
 
     public Optional<Integer> getPokemonHP() {
         return pokemonHP;

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -166,7 +166,7 @@
     <string name="ocr_error_pick_pixel_white">No se pudo seleccionar el marcador de pixel blanco\n</string>
     <string name="ocr_error_locate_pixel_green">No se pudo encontrar el marcador de pixel verde\n</string>
     <string name="ocr_error_pick_pixel_green">No se pudo seleccionar el marcador de pixel verde\n</string>
-    <string name="ocr_msg_verify">\n¡ATENCIÓN! Por favor verifica que:\n① La ficha está subida hasta arriba del todo\n② El modelo 3D no tapa ninguna información importante\n③ ¡No es una evolución final! ¡Se recomienda un Pidgey!</string>
+    <string name="ocr_msg_verify">\n¡ATENCIÓN! Por favor verifica que:\n① La ficha está subida hasta arriba del todo\n② El modelo 3D no tapa ninguna información importante\n③ ¡No es una evolución final! ¡Se recomienda un Caterpie!</string>
     <string name="ocr_calibration_saved">¡Calibración guardada!\n¡Reinicia GoIV para aplicar los cambios!</string>
     <string name="ocr_finding_name">Buscando área nombre</string>
     <string name="ocr_finding_type">Buscando área tipo</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -165,7 +165,7 @@
     <string name="ocr_error_pick_pixel_white">Impossibile ottenere il colore del pixel marcatore bianco</string>
     <string name="ocr_error_pick_pixel_green">Impossibile ottenere il colore del pixel marcatore verde</string>
     <string name="ocr_error_locate_pixel_green">Impossibile localizzare il pixel marcatore verde</string>
-    <string name="ocr_msg_verify">"\nATTENTION! Verifica che:\n① La schermata delle informazioni sia scrollata fino in cima\n② Il modello 3D non copra nessuna informazione importante\n③ Non è un'evoluzione finale! Suggerisco di provare con un Pidgey!"</string>
+    <string name="ocr_msg_verify">"\nATTENTION! Verifica che:\n① La schermata delle informazioni sia scrollata fino in cima\n② Il modello 3D non copra nessuna informazione importante\n③ Non è un'evoluzione finale! Suggerisco di provare con un Caterpie!"</string>
     <string name="ocr_calibration_saved">Calibrazione salvata! Riavvia GoIV per applicare le modifiche!</string>
     <string name="ocr_finding_name">Localizzando l\'area del nome</string>
     <string name="ocr_finding_type">Localizzando l\'area del tipo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,7 +212,7 @@
     <string name="ocr_error_pick_pixel_white">Unable to pick white marker pixel color\n</string>
     <string name="ocr_error_locate_pixel_green">Unable to locate green marker pixel\n</string>
     <string name="ocr_error_pick_pixel_green">Unable to pick green marker pixel color\n</string>
-    <string name="ocr_msg_verify">\nATTENTION! Please verify that:\n① The info screen is scrolled all the way up\n② The 3D model doesn\'t cover any important information\n③ Is not a final evolution! I suggest a Caterpie!\n④ Is not lucky or shadow\n⑤Doesn\'t have mega energy</string>
+    <string name="ocr_msg_verify">\nATTENTION! Please verify that:\n① The info screen is scrolled all the way up\n② The 3D model doesn\'t cover any important information\n③ Is not a final evolution! I suggest a Caterpie!\n④ Is not lucky or shadow\n⑤ Doesn\'t have mega energy</string>
     <string name="ocr_calibration_saved">Calibration saved!\nRestart GoIV to apply the changes!</string>
     <string name="ocr_finding_name">Finding name area</string>
     <string name="ocr_finding_type">Finding type area</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,7 +212,7 @@
     <string name="ocr_error_pick_pixel_white">Unable to pick white marker pixel color\n</string>
     <string name="ocr_error_locate_pixel_green">Unable to locate green marker pixel\n</string>
     <string name="ocr_error_pick_pixel_green">Unable to pick green marker pixel color\n</string>
-    <string name="ocr_msg_verify">\nATTENTION! Please verify that:\n① The info screen is scrolled all the way up\n② The 3D model doesn\'t cover any important information\n③ Is not a final evolution! I suggest a Caterpie!\n④ Is not lucky</string>
+    <string name="ocr_msg_verify">\nATTENTION! Please verify that:\n① The info screen is scrolled all the way up\n② The 3D model doesn\'t cover any important information\n③ Is not a final evolution! I suggest a Caterpie!\n④ Is not lucky or shadow\n⑤Doesn\'t have mega energy</string>
     <string name="ocr_calibration_saved">Calibration saved!\nRestart GoIV to apply the changes!</string>
     <string name="ocr_finding_name">Finding name area</string>
     <string name="ocr_finding_type">Finding type area</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,7 +212,7 @@
     <string name="ocr_error_pick_pixel_white">Unable to pick white marker pixel color\n</string>
     <string name="ocr_error_locate_pixel_green">Unable to locate green marker pixel\n</string>
     <string name="ocr_error_pick_pixel_green">Unable to pick green marker pixel color\n</string>
-    <string name="ocr_msg_verify">\nATTENTION! Please verify that:\n① The info screen is scrolled all the way up\n② The 3D model doesn\'t cover any important information\n③ Is not a final evolution! I suggest a Pidgey!\n④ Is not lucky</string>
+    <string name="ocr_msg_verify">\nATTENTION! Please verify that:\n① The info screen is scrolled all the way up\n② The 3D model doesn\'t cover any important information\n③ Is not a final evolution! I suggest a Caterpie!\n④ Is not lucky</string>
     <string name="ocr_calibration_saved">Calibration saved!\nRestart GoIV to apply the changes!</string>
     <string name="ocr_finding_name">Finding name area</string>
     <string name="ocr_finding_type">Finding type area</string>


### PR DESCRIPTION
Currently the calibrator only sets up one field, which the scan logic then splits into two. This split should probably occur in the calibrator, to open the possibility to configure each separately

Also need to add code for handling new offsets (see Issue #10) for more details before this can really be considered done